### PR TITLE
Set configuration to use the production back-end.

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,4 +1,4 @@
 export default class config {
-    static backEndUrl = "https://matchmakerstaging.azurewebsites.net";
+    static backEndUrl = "https://app.matchmakeredlabs.net";
     static sessionTag = "mm";
 }


### PR DESCRIPTION
The staging instance has the development back-end which is still being tested. Setting UX development to the production back-end keeps int functioning in the interim.